### PR TITLE
Fix render warning in material-section.js

### DIFF
--- a/src/app/container/material-section.js
+++ b/src/app/container/material-section.js
@@ -133,7 +133,7 @@ const MaterialSection = ({
 
     return (
       <MaterialCard
-        key={finishGroup.name}
+        key={finishGroup.id}
         title={finishGroup.name}
         subline={finishGroup.materialName}
         shipping={bestOffer && formatDeliveryTime(bestOffer.shipping.deliveryTime)}


### PR DESCRIPTION
When I started to work on #309, I realized that there are some warnings in the console regarding the render key:

![bildschirmfoto 2017-10-09 um 18 06 03](https://user-images.githubusercontent.com/781746/31347700-774d7954-ad1d-11e7-91fb-473d70de7104.jpg)

It looks like the `MaterialSection` component uses the `finishGroup.name` as render key, which can be ambiguous. Example: Premium Plastic and Premium Plastic Priority both have a "Polished" finish group. As a result, it appears like some material cards have not been rendered.

### Before fix

![screencapture-localhost-3000-1507565319497](https://user-images.githubusercontent.com/781746/31347860-05bef9ce-ad1e-11e7-83a0-00b3bb89ed39.png)

### After fix

![screencapture-localhost-3000-1507565285306](https://user-images.githubusercontent.com/781746/31347868-0fd523c0-ad1e-11e7-8553-cbebe05c821d.png)

