### PR TITLE
Fix missing await order

### DIFF
--- a/src/app/action/order.js
+++ b/src/app/action/order.js
@@ -77,6 +77,6 @@ export const createOrderWithPaypal = (data, actions) => async (dispatch) => {
   const payment = await paypal.executePayment({actions})
   const token = payment.id
 
-  dispatch(createOrder('paypal', token))
+  await dispatch(createOrder('paypal', token))
   return payment
 }


### PR DESCRIPTION
This commit fixes a bug where the application responded with a success before waiting for the order request to finish.

I don't know how this bug could have been caught by a test. I'm happy to add one, suggestions welcome! :)

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] The PR has been reviewed
- [ ] There are no 'hacks' or shortcuts refactoring is prefered

## Tests
- [ ] Reasonably tested with high code coverage (unit/integration)

##	Testability
- [ ] All exported functions are testable
- [ ] There is no code execution in the global scope
- [ ] Default exports are avoided
- [ ] The code is concise, expressive and readable
- [ ] The code is functional and doesn’t use class syntax

## React components are
- [ ] Stateless and use pure rendering functions
- [ ] Are documented and tested in storybook
- [ ] Typed-checked
- [ ] The Sass is stickily using the BEM-Convention
- [ ] For each react component exists exactly one Sass-File
- [ ] The is no container styled
- [ ] There are no console errors or unwanted console logs
