### PR TITLE
Fix react router issue, caused by api change in v4

### DIFF
--- a/src/app/container/configuration-page.js
+++ b/src/app/container/configuration-page.js
@@ -23,7 +23,7 @@ export default compose(
   withState('isLoading', 'setIsLoading', true),
   lifecycle({
     componentWillMount() {
-      const {params, configurationId, onRestoreConfiguration} = this.props
+      const {match: {params}, configurationId, onRestoreConfiguration} = this.props
 
       // Restore only if configuration id changed
       if (configurationId !== params.id) {

--- a/src/app/lib/selector.js
+++ b/src/app/lib/selector.js
@@ -206,7 +206,7 @@ export const selectAreAllUploadsFinished = state => {
 }
 
 export const selectLocationQuery = state =>
-  new URLSearchParams(get(state, 'routing.location.query') || '')
+  new URLSearchParams(get(state, 'routing.location.search') || '')
 
 export const selectFeatures = state => {
   const query = selectLocationQuery(state)

--- a/test/unit/app/action/price.spec.js
+++ b/test/unit/app/action/price.spec.js
@@ -50,7 +50,7 @@ describe('Price actions', () => {
       },
       routing: {
         location: {
-          query: 'feature:refresh'
+          search: 'feature:refresh'
         }
       }
     }

--- a/test/unit/app/lib/selector.spec.js
+++ b/test/unit/app/lib/selector.spec.js
@@ -790,7 +790,7 @@ describe('Selector lib', () => {
         selectFeatures({
           routing: {
             location: {
-              query: query.toString()
+              search: query.toString()
             }
           }
         }),
@@ -812,7 +812,7 @@ describe('Selector lib', () => {
         selectFeatures({
           routing: {
             location: {
-              query: query.toString()
+              search: query.toString()
             }
           }
         }),
@@ -848,7 +848,7 @@ describe('Selector lib', () => {
         const params = selectLocationQuery({
           routing: {
             location: {
-              query: 'a&b=false&c=2'
+              search: 'a&b=false&c=2'
             }
           }
         })


### PR DESCRIPTION
This issue was caused to api changes in the new react-router v4
They renamed `props.params` to `props.match.params`
And `location.query` to `location.search`