### PR TITLE
Add Sentry integration

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
+const webpack = require('webpack')
 const config = require('../webpack.config')
 
 const jsTestRegExpString = /\.js$/.toString()
@@ -8,7 +9,7 @@ const rules = config.module.rules.filter(
   rule => !rule.test || rule.test.toString() !== jsTestRegExpString
 )
 
-config.plugins = config.plugins.filter(plugin => plugin instanceof HtmlWebpackPlugin === false)
+config.plugins = config.plugins.filter(plugin => plugin instanceof HtmlWebpackPlugin === false && plugin instanceof webpack.optimize.UglifyJsPlugin === false)
 
 module.exports = {
   resolve: config.resolve,

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -9,7 +9,11 @@ const rules = config.module.rules.filter(
   rule => !rule.test || rule.test.toString() !== jsTestRegExpString
 )
 
-config.plugins = config.plugins.filter(plugin => plugin instanceof HtmlWebpackPlugin === false && plugin instanceof webpack.optimize.UglifyJsPlugin === false)
+config.plugins = config.plugins.filter(
+  plugin =>
+    plugin instanceof HtmlWebpackPlugin === false &&
+    plugin instanceof webpack.optimize.UglifyJsPlugin === false
+)
 
 module.exports = {
   resolve: config.resolve,

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,6 @@ deploy:
   on:
     repo: all3dp/printing-engine-client
     branch: master
-after_deploy: ./bin/purge-cloudflare-cache.sh
+after_deploy:
+  - ./bin/create-sentry-release.sh
+  - ./bin/purge-cloudflare-cache.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ npm run start
 
 - `CLOUDFLARE_USER`: Required to deploy the production build on the CDN
 - `CLOUDFLARE_API_KEY`: Required to deploy the production build on the CDN
+- `SENTRY_AUTH_TOKEN`: Required to create the sentry release and deploy
 
 ### Run time
 

--- a/bin/.sentryignore
+++ b/bin/.sentryignore
@@ -1,0 +1,2 @@
+styleguide
+*.css.map

--- a/bin/create-sentry-release.sh
+++ b/bin/create-sentry-release.sh
@@ -4,15 +4,15 @@
 set -eu
 
 # SENTRY_AUTH_TOKEN must be set externally
+# exported env variables are used by the sentry-cli
 export SENTRY_ORG="all3dp-gmbh"
 export SENTRY_PROJECT="printing-engine-client"
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DIST_PATH="./dist"
-SOURCE_MAPS=$(find $DIST_PATH -name '*.js.map' -type f)
-VERSION=$( $SCRIPT_PATH/get-sentry-release-version.sh )
+VERSION=$( "$SCRIPT_PATH"/get-sentry-release-version.sh )
 
-npx sentry-cli releases new $VERSION
-npx sentry-cli releases set-commits --auto $VERSION
-npx sentry-cli releases files $VERSION upload-sourcemaps --rewrite --ignore-file $SCRIPT_PATH/.sentryignore $DIST_PATH
-npx sentry-cli releases finalize $VERSION
-npx sentry-cli releases deploys $VERSION new -e production
+npx sentry-cli releases new "$VERSION"
+npx sentry-cli releases set-commits --auto "$VERSION"
+npx sentry-cli releases files "$VERSION" upload-sourcemaps --rewrite --ignore-file "$SCRIPT_PATH"/.sentryignore "$DIST_PATH"
+npx sentry-cli releases finalize "$VERSION"
+npx sentry-cli releases deploys "$VERSION" new -e production

--- a/bin/create-sentry-release.sh
+++ b/bin/create-sentry-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash -eu
+
+ORGANIZATION="all3dp-gmbh"
+PROJECT="printing-engine-client"
+RELEASE=$RELEASE_ID
+TOKEN=$SENTRY_API_TOKEN
+URL=$DEPLOY_URL
+DIST_PATH="./dist"
+
+printf "Creating sentry release $RELEASE_ID..."
+curl https://sentry.io/api/0/projects/$ORGANIZATION/$PROJECT/releases/ \
+  -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"version\": \"$RELEASE\"}" \
+  -f -v
+printf "\nDone."
+
+cd $DIST_PATH
+
+for line in $(find . -name '*.js.map' -type f | sed 's|./||'); do
+
+  printf "Uploading $line..."
+  curl https://sentry.io/api/0/projects/$ORGANIZATION/$PROJECT/releases/$RELEASE/files/ \
+    -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -F file=@$line \
+    -F name="$DEPLOY_URL/$line" \
+    -f -v
+  printf "\nDone."
+
+done
+
+cd ..

--- a/bin/create-sentry-release.sh
+++ b/bin/create-sentry-release.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
+
+# fail early on simple command errors and missing env variables
+set -eu
 
 npm i sentry-cli-binary
 

--- a/bin/get-sentry-release-version.sh
+++ b/bin/get-sentry-release-version.sh
@@ -1,0 +1,1 @@
+npx sentry-cli releases propose-version

--- a/bin/purge-cloudflare-cache.sh
+++ b/bin/purge-cloudflare-cache.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -eu
 
 ZONE="924763cc40afc8b78600536e6eb5c652"
 

--- a/bin/purge-cloudflare-cache.sh
+++ b/bin/purge-cloudflare-cache.sh
@@ -1,4 +1,7 @@
-#!/usr/bin/env bash -eu
+#!/usr/bin/env bash
+
+# fail early on simple command errors and missing env variables
+set -eu
 
 ZONE="924763cc40afc8b78600536e6eb5c652"
 

--- a/config/default.js
+++ b/config/default.js
@@ -11,6 +11,7 @@ export default {
   debouncePriceRequestWait: 1000,
   defaultSelectedMaterial: 'Premium Plastic',
   stripeCheckoutImage: 'asset/image/checkout-logo.png',
-  raven: 'https://ea87ef20371a4316aca7c9f415aad1f9@sentry.io/193367',
+  ravenUrl: 'https://ea87ef20371a4316aca7c9f415aad1f9@sentry.io/193367',
+  ravenRelease: process.env.SENTRY_RELEASE_VERSION,
   ipApiKey: '0TrLHRAixWyJhe3'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14339,6 +14339,23 @@
         "statuses": "1.3.1"
       }
     },
+    "sentry-cli-binary": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/sentry-cli-binary/-/sentry-cli-binary-1.22.0.tgz",
+      "integrity": "sha1-JfDmeEpGfSh6uwnTK54ulGqtLNg=",
+      "dev": true,
+      "requires": {
+        "progress": "2.0.0"
+      },
+      "dependencies": {
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        }
+      }
+    },
     "serve-favicon": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "redux-mock-store": "^1.2.3",
     "sass-loader": "^6.0.6",
     "semver": "^5.1.0",
+    "sentry-cli-binary": "^1.22.0",
     "sinon": "^4.0.1",
     "source-map-support": "^0.5.0",
     "standard": "^10.0.3",

--- a/src/app/service/logging.js
+++ b/src/app/service/logging.js
@@ -4,7 +4,9 @@ import createRavenMiddleware from 'raven-for-redux'
 import config from '../../../config'
 
 if (process.env.NODE_ENV === 'production') {
-  Raven.config(config.raven).install()
+  Raven.config(config.ravenUrl, {
+    release: config.ravenRelease
+  }).install()
 }
 
 export const captureException = exception => Raven && Raven.captureException(exception)

--- a/src/app/service/logging.js
+++ b/src/app/service/logging.js
@@ -5,7 +5,8 @@ import config from '../../../config'
 
 if (process.env.NODE_ENV === 'production') {
   Raven.config(config.ravenUrl, {
-    release: config.ravenRelease
+    release: config.ravenRelease,
+    environment: process.env.NODE_ENV
   }).install()
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const childProcess = require('child_process')
 const compact = require('lodash/compact')
 const path = require('path')
 const webpack = require('webpack')
@@ -10,6 +11,12 @@ const projectRoot = __dirname
 const env = process.env.WEBPACK_ENV || 'development'
 const isProd = env === 'production'
 const isDev = isProd === false
+const sentryReleaseVersion = isProd
+  ? childProcess
+      .execSync(path.resolve(__dirname, 'bin', 'get-sentry-release-version.sh'))
+      .toString()
+      .trim()
+  : 'no-sentry-release'
 
 module.exports = {
   bail: isProd,
@@ -121,7 +128,8 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify(env)
+        NODE_ENV: JSON.stringify(env),
+        SENTRY_RELEASE_VERSION: JSON.stringify(sentryReleaseVersion)
       }
     }),
     new HtmlPlugin({


### PR DESCRIPTION
This PR adds the Sentry integration for full source map support. Fixes #375.

With this Sentry integration, we should get:

- Source map support
- Commit integration for Sentry. For instance, by adding `Fixes SENTRY-317` to the commit message, Sentry is able to show which issues have been fixed by which release (and automatically close them).

See also https://docs.sentry.io/learn/cli/releases/

**Before this PR can be merged, we need to:**

- [x] Connect our Sentry project with the GitHub repository (I'm not allowed to do that)
- [x] Add the SENTRY_AUTH_TOKEN env variable to Travis

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] The PR has been reviewed
- [ ] There are no 'hacks' or shortcuts refactoring is prefered

## Tests
- [ ] Reasonably tested with high code coverage (unit/integration)

##	Testability
- [ ] All exported functions are testable
- [ ] There is no code execution in the global scope
- [ ] Default exports are avoided
- [ ] The code is concise, expressive and readable
- [ ] The code is functional and doesn’t use class syntax

## React components are
- [ ] Stateless and use pure rendering functions
- [ ] Are documented and tested in storybook
- [ ] Typed-checked
- [ ] The Sass is stickily using the BEM-Convention
- [ ] For each react component exists exactly one Sass-File
- [ ] The is no container styled
- [ ] There are no console errors or unwanted console logs
