### PR TITLE
Fix unexpected error during address input

### DIFF
--- a/src/app/action/price.js
+++ b/src/app/action/price.js
@@ -4,7 +4,7 @@ import type {Dispatch} from 'redux'
 import {createAction} from 'redux-actions'
 
 import * as printingEngine from 'Lib/printing-engine'
-import {getUpdatedOffer} from 'Lib/offer'
+import {getUpdatedOffer, getCheapestOfferFor} from 'Lib/offer'
 import {poll, debouncedPoll, stopPoll} from 'Lib/poll'
 import {selectCurrentMaterial, selectFeatures} from 'Lib/selector'
 import {AppError} from 'Lib/error'
@@ -157,7 +157,13 @@ export const recalculateSelectedOffer = () => (dispatch: Dispatch<*>, getState: 
     RECALC_POLL_NAME,
     async (priceId: string) => {
       const {price} = await printingEngine.getPriceWithStatus({priceId})
-      const updatedOffer = getUpdatedOffer(selectedOffer, price.offers)
+      const updatedOffer =
+        getUpdatedOffer(selectedOffer, price.offers) ||
+        getCheapestOfferFor(
+          selectedOffer.materialConfigId,
+          selectedOffer.printingService,
+          price.offers
+        )
 
       if (!updatedOffer || updatedOffer.priceEstimated) {
         return false

--- a/src/app/lib/offer.js
+++ b/src/app/lib/offer.js
@@ -1,6 +1,11 @@
-export const getUpdatedOffer = (selectedOffer, offers) =>
+// @flow
+
+import type {Offer} from 'App/type'
+
+export const getUpdatedOffer = (selectedOffer: Offer, offers: Array<Offer>) =>
   offers.find(
     offer =>
       offer.materialConfigId === selectedOffer.materialConfigId &&
-      offer.printingService === selectedOffer.printingService
+      offer.printingService === selectedOffer.printingService &&
+      offer.shipping.name === selectedOffer.shipping.name
   ) || null

--- a/src/app/lib/offer.js
+++ b/src/app/lib/offer.js
@@ -9,3 +9,17 @@ export const getUpdatedOffer = (selectedOffer: Offer, offers: Array<Offer>) =>
       offer.printingService === selectedOffer.printingService &&
       offer.shipping.name === selectedOffer.shipping.name
   ) || null
+
+export const getCheapestOfferFor = (
+  materialConfigId: string,
+  printingService: string,
+  offers: Array<Offer>
+) => {
+  const sortedOffers = offers.slice().sort((a, b) => a.totalPrice - b.totalPrice)
+  return (
+    sortedOffers.find(
+      offer =>
+        offer.materialConfigId === materialConfigId && offer.printingService === printingService
+    ) || null
+  )
+}

--- a/test/unit/app/action/price.spec.js
+++ b/test/unit/app/action/price.spec.js
@@ -7,6 +7,7 @@ import {
 } from 'Action/price'
 import * as pollLib from 'Lib/poll'
 import * as printingEngine from 'Lib/printing-engine'
+import * as offerLib from 'Lib/offer'
 import * as modalActions from 'Action/modal'
 import {AppError} from 'Lib/error'
 import config from '../../../../config'
@@ -580,6 +581,106 @@ describe('Price actions', () => {
       await store.dispatch(recalculateSelectedOffer())
 
       expect(printingEngine.getPriceWithStatus, 'to have a call satisfying', [{priceId: 'price-1'}])
+    })
+
+    it('calls getUpdatedOffer() with the expected arguments', async () => {
+      const price = {
+        offers: [offer1]
+      }
+      const store = mockStore({
+        material,
+        model,
+        user,
+        price: {
+          offers: [offer1],
+          selectedOffer: offer1
+        }
+      })
+      printingEngine.createPriceRequest.resolves({priceId: 'price-1'})
+      printingEngine.getPriceWithStatus.resolves({price})
+      sandbox.stub(offerLib, 'getUpdatedOffer')
+
+      await store.dispatch(recalculateSelectedOffer())
+
+      expect(offerLib.getUpdatedOffer, 'to have a call satisfying', [offer1, price.offers])
+    })
+
+    it('selects the updated offer from getUpdatedOffer()', async () => {
+      const price = {
+        offers: [offer1]
+      }
+      const store = mockStore({
+        material,
+        model,
+        user,
+        price: {
+          offers: [offer1],
+          selectedOffer: offer1
+        }
+      })
+      printingEngine.createPriceRequest.resolves({priceId: 'price-1'})
+      printingEngine.getPriceWithStatus.resolves({price})
+      sandbox.stub(offerLib, 'getUpdatedOffer').returns(offer2)
+
+      await store.dispatch(recalculateSelectedOffer())
+
+      expect(store.getActions(), 'to contain', {
+        type: TYPE.PRICE.SELECT_OFFER,
+        payload: {offer: offer2}
+      })
+    })
+
+    it('calls getCheapestOfferFor() with the expected arguments if getUpdatedOffer() returns null', async () => {
+      const price = {
+        offers: [offer1]
+      }
+      const store = mockStore({
+        material,
+        model,
+        user,
+        price: {
+          offers: [offer1],
+          selectedOffer: offer1
+        }
+      })
+      printingEngine.createPriceRequest.resolves({priceId: 'price-1'})
+      printingEngine.getPriceWithStatus.resolves({price})
+      sandbox.stub(offerLib, 'getUpdatedOffer').returns(null)
+      sandbox.stub(offerLib, 'getCheapestOfferFor').returns(offer2)
+
+      await store.dispatch(recalculateSelectedOffer())
+
+      expect(offerLib.getCheapestOfferFor, 'to have a call satisfying', [
+        offer1.materialConfigId,
+        offer1.printingService,
+        price.offers
+      ])
+    })
+
+    it('selects the cheapest offer from getCheapestOfferFor() if getUpdatedOffer() returns null', async () => {
+      const price = {
+        offers: [offer1]
+      }
+      const store = mockStore({
+        material,
+        model,
+        user,
+        price: {
+          offers: [offer1],
+          selectedOffer: offer1
+        }
+      })
+      printingEngine.createPriceRequest.resolves({priceId: 'price-1'})
+      printingEngine.getPriceWithStatus.resolves({price})
+      sandbox.stub(offerLib, 'getUpdatedOffer').returns(null)
+      sandbox.stub(offerLib, 'getCheapestOfferFor').returns(offer2)
+
+      await store.dispatch(recalculateSelectedOffer())
+
+      expect(store.getActions(), 'to contain', {
+        type: TYPE.PRICE.SELECT_OFFER,
+        payload: {offer: offer2}
+      })
     })
 
     it('dispatches expected actions when polling fails with fatal error', async () => {

--- a/test/unit/app/action/price.spec.js
+++ b/test/unit/app/action/price.spec.js
@@ -67,15 +67,24 @@ describe('Price actions', () => {
   }
   const offer1 = {
     materialConfigId: 'material-config-1',
-    printingService: 'service-1'
+    printingService: 'service-1',
+    shipping: {
+      name: 'some-shipping'
+    }
   }
   const offer2 = {
     materialConfigId: 'material-config-1',
-    printingService: 'service-2'
+    printingService: 'service-2',
+    shipping: {
+      name: 'some-shipping'
+    }
   }
   const offer3 = {
     materialConfigId: 'material-config-2',
-    printingService: 'service-1'
+    printingService: 'service-1',
+    shipping: {
+      name: 'some-shipping'
+    }
   }
   let sandbox
 

--- a/test/unit/app/lib/offer.spec.js
+++ b/test/unit/app/lib/offer.spec.js
@@ -5,40 +5,17 @@ describe('Offer unit tests', () => {
     it('works for a default input', () => {
       const selectedOffer = {
         materialConfigId: 'some-config-id',
-        printingService: 'some-printing-service'
-      }
-      const offers = [
-        {
-          materialConfigId: 'other-config-id',
-          printingService: 'other-printing-service'
-        },
-        {
-          materialConfigId: 'some-config-id',
-          printingService: 'some-printing-service'
+        printingService: 'some-printing-service',
+        shipping: {
+          name: 'some-shipping'
         }
-      ]
-
-      expect(getUpdatedOffer(selectedOffer, offers), 'to be', offers[1])
-    })
-
-    it('returns the first match for the given materialConfigId and the printingService', () => {
-      const selectedOffer = {
-        materialConfigId: 'some-config-id',
-        printingService: 'some-printing-service'
       }
       const offers = [
         {
           materialConfigId: 'some-config-id',
           printingService: 'some-printing-service',
           shipping: {
-            name: 'dhl'
-          }
-        },
-        {
-          materialConfigId: 'some-config-id',
-          printingService: 'some-printing-service',
-          shipping: {
-            name: 'other'
+            name: 'some-shipping'
           }
         }
       ]
@@ -46,15 +23,21 @@ describe('Offer unit tests', () => {
       expect(getUpdatedOffer(selectedOffer, offers), 'to be', offers[0])
     })
 
-    it('returns null for no match', () => {
+    it('retuns null for no match', () => {
       const selectedOffer = {
         materialConfigId: 'some-config-id',
-        printingService: 'some-printing-service'
+        printingService: 'some-printing-service',
+        shipping: {
+          name: 'some-shipping'
+        }
       }
       const offers = [
         {
           materialConfigId: 'some-config-id-2',
-          printingService: 'some-printing-service'
+          printingService: 'some-printing-service',
+          shipping: {
+            name: 'some-shipping'
+          }
         }
       ]
 

--- a/test/unit/app/lib/offer.spec.js
+++ b/test/unit/app/lib/offer.spec.js
@@ -1,4 +1,4 @@
-import {getUpdatedOffer} from 'Lib/offer'
+import {getUpdatedOffer, getCheapestOfferFor} from 'Lib/offer'
 
 describe('Offer unit tests', () => {
   describe('getUpdatedOffer()', () => {
@@ -23,9 +23,9 @@ describe('Offer unit tests', () => {
       expect(getUpdatedOffer(selectedOffer, offers), 'to be', offers[0])
     })
 
-    it('retuns null for no match', () => {
+    it('returns null for no match', () => {
       const selectedOffer = {
-        materialConfigId: 'some-config-id',
+        materialConfigId: 'some-config-id-1',
         printingService: 'some-printing-service',
         shipping: {
           name: 'some-shipping'
@@ -42,6 +42,76 @@ describe('Offer unit tests', () => {
       ]
 
       expect(getUpdatedOffer(selectedOffer, offers), 'to be', null)
+    })
+
+    it('returns null when the given offers array is empty', () => {
+      expect(
+        getUpdatedOffer(
+          {
+            materialConfigId: 'some-config-id-1',
+            printingService: 'some-printing-service',
+            shipping: {
+              name: 'some-shipping'
+            }
+          },
+          []
+        ),
+        'to be',
+        null
+      )
+    })
+  })
+
+  describe('getCheapestOfferFor()', () => {
+    it('returns the cheapest offer for the given materialConfigId and printingService', () => {
+      const baseOffer = {
+        materialConfigId: 'some-config-id',
+        printingService: 'some-printing-service'
+      }
+      const offers = [
+        {
+          ...baseOffer,
+          totalPrice: 20.12
+        },
+        {
+          ...baseOffer,
+          totalPrice: 18.21
+        },
+        {
+          ...baseOffer,
+          totalPrice: 18.2
+        }
+      ]
+
+      expect(
+        getCheapestOfferFor('some-config-id', 'some-printing-service', offers),
+        'to be',
+        // implicit check if offers array has not been modified by sort()
+        offers[2]
+      )
+    })
+
+    it('returns null if there is no offer for the given materialConfigId and printingService', () => {
+      const baseOffer = {
+        materialConfigId: 'some-config-id',
+        printingService: 'some-printing-service'
+      }
+      const offers = [
+        {
+          ...baseOffer,
+          totalPrice: 20.12
+        }
+      ]
+
+      expect(
+        getCheapestOfferFor('other-config-id', 'other-printing-service', offers),
+        'to be',
+        null
+      )
+    })
+
+    it('returns null when the given offers array is empty', () => {
+      expect(getCheapestOfferFor('some-config-id', 'some-printing-service', []), 'to be', null)
     })
   })
 })


### PR DESCRIPTION
Fixes #415

This PR reverts some of the changes that have been introduced with https://github.com/all3dp/printing-engine-client/commit/1a34ed8871d0d0d2c1e80a03eae83649787f778f: We take the `shipping.name` into account again to find the updated offer. Otherwise it just selects the first offer that has the same `materialConfigId` and `printingService`, neglecting the actual shipping method. This led to a situation where the shipping method was actually changed, based on the random order of the offer (thus the alert about the changed price, the price did actually change!)

Now if the updated offer is not available anymore, we just select the cheapest offer for this `materialConfigId` and for the given `printingService`.

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] The PR has been reviewed
- [ ] There are no 'hacks' or shortcuts refactoring is prefered

## Tests
- [ ] Reasonably tested with high code coverage (unit/integration)

##	Testability
- [ ] All exported functions are testable
- [ ] There is no code execution in the global scope
- [ ] Default exports are avoided
- [ ] The code is concise, expressive and readable
- [ ] The code is functional and doesn’t use class syntax

## React components are
- [ ] Stateless and use pure rendering functions
- [ ] Are documented and tested in storybook
- [ ] Typed-checked
- [ ] The Sass is stickily using the BEM-Convention
- [ ] For each react component exists exactly one Sass-File
- [ ] The is no container styled
- [ ] There are no console errors or unwanted console logs
