### PR TITLE
Fix wrong city name in geolocation

### DIFF
--- a/src/app/type-next.js
+++ b/src/app/type-next.js
@@ -85,7 +85,8 @@ export type Address = Location & {
 export type GoogleMapsPlace = {
   address_components: ?Array<{
     types: Array<string>,
-    short_name: string
+    short_name: string,
+    long_name: string
   }>
 }
 

--- a/test/unit/app/lib/geolocation.spec.js
+++ b/test/unit/app/lib/geolocation.spec.js
@@ -74,7 +74,7 @@ describe('geolocation lib', () => {
           },
           {
             long_name: 'Ulm',
-            short_name: 'Ulm',
+            short_name: 'UL',
             types: ['locality', 'political']
           },
           {
@@ -115,7 +115,7 @@ describe('geolocation lib', () => {
         address_components: [
           {
             long_name: 'Ulm',
-            short_name: 'Ulm',
+            short_name: 'UL',
             types: ['locality', 'political']
           },
           {


### PR DESCRIPTION
Beim Testen ist mir immer wieder aufgefallen, dass bei uns im Büro in Augsburg bei der Location `A, Germany` kommt:

![bildschirmfoto 2017-12-11 um 19 34 26](https://user-images.githubusercontent.com/781746/33889856-bd07120a-df51-11e7-86be-9114662fe65b.jpg)

![bildschirmfoto 2017-12-11 um 19 34 35](https://user-images.githubusercontent.com/781746/33889847-b1e5e7f2-df51-11e7-9224-2f426d12b7f7.jpg)

Es sieht wohl so aus, dass Google nicht eindeutig standartisiert hat, was `short_name` und `long_name` ist. Es macht aber aus meiner Sicht Sinn, beim Straßennamen und bei der Stadt den `long_name` zu verwenden (`short_name` scheint bei manchen Städten das Autokennzeichen zu sein). Deshalb die Änderung.

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
