### PR TITLE
Fix unsupported style property warning in stories

### DIFF
--- a/stories/component/button.js
+++ b/stories/component/button.js
@@ -23,7 +23,7 @@ storiesOf('Button', module)
     <Button label="Selected Button" modifiers={['selected']} onClick={action('click')} />
   ))
   .add('invert', () => (
-    <div className="u-invert" style={{width: '100%', 'min-height': '100vh'}}>
+    <div className="u-invert" style={{width: '100%', minHeight: '100vh'}}>
       <Button label="Inverted Button" modifiers={['invert']} onClick={action('click')} />
     </div>
   ))

--- a/stories/component/icon-link.js
+++ b/stories/component/icon-link.js
@@ -11,12 +11,12 @@ storiesOf('Icon Link', module)
   .add('default', () => <IconLink icon={placeholderIcon} onClick={action('click')} />)
   .add('disabled', () => <IconLink icon={placeholderIcon} disabled onClick={action('click')} />)
   .add('invert', () => (
-    <div className="u-invert" style={{width: '100%', 'min-height': '100vh'}}>
+    <div className="u-invert" style={{width: '100%', minHeight: '100vh'}}>
       <IconLink icon={placeholderIcon} modifiers={['invert']} onClick={action('click')} />
     </div>
   ))
   .add('invert & disabled', () => (
-    <div className="u-invert" style={{width: '100%', 'min-height': '100vh'}}>
+    <div className="u-invert" style={{width: '100%', minHeight: '100vh'}}>
       <IconLink icon={placeholderIcon} modifiers={['invert']} disabled onClick={action('click')} />
     </div>
   ))

--- a/stories/component/link.js
+++ b/stories/component/link.js
@@ -12,7 +12,7 @@ storiesOf('Link', module)
     <Link label="Link with Icon" href="#" icon={backIcon} onClick={action('click')} />
   ))
   .add('invert', () => (
-    <div className="u-invert" style={{width: '100%', 'min-height': '100vh'}}>
+    <div className="u-invert" style={{width: '100%', minHeight: '100vh'}}>
       <Link label="Inverted Link" modifiers={['invert']} href="#" onClick={action('click')} />
     </div>
   ))


### PR DESCRIPTION
Ist mir aufgefallen, als ich gerade an meinem ModelViewer-PR gearbeitet habe. Die Style-Property muss in CamelCase angegeben werden:

![bildschirmfoto 2018-01-16 um 18 27 50](https://user-images.githubusercontent.com/781746/35002842-3a5eab5a-faeb-11e7-8dec-f8be3c1c1187.jpg)

# Definition of Done

- [x] The code does at least what is defined in the ticket and does not affect any other functionality
- [x] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [x] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
