### PR TITLE
Refactor createPriceRequest action

### DIFF
--- a/src/app/action/material.js
+++ b/src/app/action/material.js
@@ -7,7 +7,6 @@ import * as printingEngine from '../service/printing-engine'
 
 import TYPE from '../action-type'
 import type {MaterialGroup} from '../type-next'
-import {createPriceRequest} from './price'
 
 // Sync actions
 
@@ -16,7 +15,7 @@ export const selectMaterial = createAction(
   (materialId: string) => materialId
 )
 
-const materialGroupSelected = createAction(
+export const materialGroupSelected = createAction(
   TYPE.MATERIAL.GROUP_SELECTED,
   (groupId: string) => groupId
 )
@@ -46,12 +45,6 @@ const materialReceived = createAction(
 )
 
 // Async actions
-
-export const selectMaterialGroup = (groupId: string) => async (dispatch: Dispatch<*>) => {
-  dispatch(materialGroupSelected(groupId))
-
-  await dispatch(createPriceRequest())
-}
 
 export const getMaterials = () => async (dispatch: Dispatch<*>) => {
   const materialResponse = await printingEngine.listMaterials()

--- a/src/app/action/material.js
+++ b/src/app/action/material.js
@@ -15,7 +15,7 @@ export const selectMaterial = createAction(
   (materialId: string) => materialId
 )
 
-export const materialGroupSelected = createAction(
+export const selectMaterialGroup = createAction(
   TYPE.MATERIAL.GROUP_SELECTED,
   (groupId: string) => groupId
 )

--- a/src/app/container/material-section.js
+++ b/src/app/container/material-section.js
@@ -26,7 +26,7 @@ import RadioButtonGroup from '../component/radio-button-group'
 import MaterialSlider from '../component/material-slider'
 import Link from '../component/link'
 
-import {selectMaterial, materialGroupSelected} from '../action/material'
+import {selectMaterial, selectMaterialGroup} from '../action/material'
 import {openMaterialModal} from '../action/modal'
 
 import {connectLegacy} from './util/connect-legacy'
@@ -142,7 +142,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   onSelectMaterial: selectMaterial,
-  onSelectMaterialGroup: materialGroupSelected,
+  onSelectMaterialGroup: selectMaterialGroup,
   onOpenMaterialModal: openMaterialModal
 }
 

--- a/src/app/container/material-section.js
+++ b/src/app/container/material-section.js
@@ -26,7 +26,7 @@ import RadioButtonGroup from '../component/radio-button-group'
 import MaterialSlider from '../component/material-slider'
 import Link from '../component/link'
 
-import {selectMaterial, selectMaterialGroup} from '../action/material'
+import {selectMaterial, materialGroupSelected} from '../action/material'
 import {openMaterialModal} from '../action/modal'
 
 import {connectLegacy} from './util/connect-legacy'
@@ -142,7 +142,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   onSelectMaterial: selectMaterial,
-  onSelectMaterialGroup: selectMaterialGroup,
+  onSelectMaterialGroup: materialGroupSelected,
   onOpenMaterialModal: openMaterialModal
 }
 

--- a/test/integration/app/action/material.spec.js
+++ b/test/integration/app/action/material.spec.js
@@ -1,6 +1,10 @@
 import createHistory from 'history/createMemoryHistory'
 
-import {getMaterials, selectMaterialConfig} from '../../../../src/app/action/material'
+import {
+  getMaterials,
+  selectMaterialGroup,
+  selectMaterialConfig
+} from '../../../../src/app/action/material'
 import * as printingEngine from '../../../../src/app/service/printing-engine'
 
 describe('Material Integration Test', () => {
@@ -16,6 +20,14 @@ describe('Material Integration Test', () => {
 
   afterEach(() => {
     sandbox.restore()
+  })
+
+  describe('selectMaterialGroup()', () => {
+    it('should select the given material group', () => {
+      store.dispatch(selectMaterialGroup('some-material-group-2'))
+
+      expect(store.getState().material.selectedMaterialGroup, 'to equal', 'some-material-group-2')
+    })
   })
 
   describe('getMaterials()', () => {

--- a/test/unit/app/action/material.spec.js
+++ b/test/unit/app/action/material.spec.js
@@ -1,4 +1,4 @@
-import {selectMaterial, selectMaterialGroup} from '../../../../src/app/action/material'
+import {selectMaterial} from '../../../../src/app/action/material'
 import * as priceActions from '../../../../src/app/action/price'
 import * as printingEngine from '../../../../src/app/service/printing-engine'
 import * as materialLib from '../../../../src/app/lib/material'
@@ -32,40 +32,6 @@ describe('Material actions', () => {
           payload: 'some-material-id'
         }
       ])
-    })
-  })
-
-  describe('selectMaterialGroup()', () => {
-    it('dispatches expected actions', () => {
-      priceActions.createPriceRequest.returns(() => 'some-price-id')
-      store.dispatch(selectMaterialGroup('group-id'))
-      expect(store.getActions(), 'to equal', [
-        {
-          type: TYPE.MATERIAL.GROUP_SELECTED,
-          payload: 'group-id'
-        }
-      ])
-    })
-
-    it('creates a price request', () => {
-      priceActions.createPriceRequest.returns(() => 'some-price-id')
-      store.dispatch(selectMaterialGroup('some-material-id'))
-      expect(priceActions.createPriceRequest, 'to have a call satisfying', [])
-    })
-
-    it('resolves with undefined', async () => {
-      priceActions.createPriceRequest.returns(async () => 'some-price-id')
-      expect(await store.dispatch(selectMaterialGroup('group-id')), 'to equal', undefined)
-    })
-
-    it('resolves after the price request has been resolved', async () => {
-      let resolved = false
-
-      priceActions.createPriceRequest.returns(async () => {
-        resolved = true
-      })
-      await store.dispatch(selectMaterialGroup('group-id'))
-      expect(resolved, 'to equal', true)
     })
   })
 })


### PR DESCRIPTION
- Skip price request when there are some models still uploading, fixes #532, fixes PRINTING-ENGINE-CLIENT-6D
- Remove lazy loading of material group prices again, fixes #538

# Definition of Done

- [x] The code does at least what is defined in the ticket and does not affect any other functionality
- [x] The PR has a meaningful title
- [x] There is a link to the issue-id
- [x] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
