### PR TITLE
Add timeout state implementation with redux-loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15716,6 +15716,11 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
     },
+    "timeout-as-promise": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/timeout-as-promise/-/timeout-as-promise-1.0.0.tgz",
+      "integrity": "sha1-c2foEfyZKs/Nzaq/LlDfr4shV28="
+    },
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "scut": "^1.4.0",
     "serve-favicon": "^2.3.0",
     "susy": "^2.2.12",
+    "timeout-as-promise": "^1.0.0",
     "timezones.json": "^1.1.0",
     "url-search-params": "^0.10.0",
     "velocity-animate": "^1.4.3",

--- a/src/app/action-next/index.js
+++ b/src/app/action-next/index.js
@@ -5,5 +5,12 @@ import type {CoreAction} from './core'
 import type {ModalAction} from './modal'
 import type {UserAction} from './user'
 import type {ModelAction} from './model'
+import type {TimeoutAction} from './timeout'
 
-export type AppAction = InitAction | CoreAction | ModalAction | UserAction | ModelAction
+export type AppAction =
+  | InitAction
+  | CoreAction
+  | ModalAction
+  | UserAction
+  | ModelAction
+  | TimeoutAction

--- a/src/app/action-next/timeout.js
+++ b/src/app/action-next/timeout.js
@@ -1,0 +1,49 @@
+// @flow
+
+import uniqueId from 'lodash/uniqueId'
+import type {Action, TimeoutId, TimeoutOnEndActionCreator} from '../type-next'
+
+type StartAction = Action<
+  'TIMEOUT.START',
+  {timeoutId: TimeoutId, onEndActionCreator: TimeoutOnEndActionCreator, delay: number}
+>
+type CancelAction = Action<'TIMEOUT.CANCEL', {timeoutId: TimeoutId}>
+type DebounceAction = Action<'TIMEOUT.DEBOUNCE', {timeoutId: TimeoutId, delay: number}>
+type InitiatorAction = StartAction | DebounceAction
+type EndAction = Action<'TIMEOUT.END', {initiatorAction: InitiatorAction}>
+
+export type TimeoutAction = StartAction | EndAction | DebounceAction | CancelAction
+
+export const start = (
+  onEndActionCreator: TimeoutOnEndActionCreator,
+  delay: number
+): StartAction => ({
+  type: 'TIMEOUT.START',
+  payload: {
+    timeoutId: uniqueId('timeout-id-'),
+    onEndActionCreator,
+    delay
+  }
+})
+
+export const cancel = (timeoutId: TimeoutId): CancelAction => ({
+  type: 'TIMEOUT.CANCEL',
+  payload: {
+    timeoutId
+  }
+})
+
+export const debounce = (timeoutId: TimeoutId, delay: number): DebounceAction => ({
+  type: 'TIMEOUT.DEBOUNCE',
+  payload: {
+    timeoutId,
+    delay
+  }
+})
+
+export const end = (initiatorAction: InitiatorAction): EndAction => ({
+  type: 'TIMEOUT.END',
+  payload: {
+    initiatorAction
+  }
+})

--- a/src/app/action-next/timeout.js
+++ b/src/app/action-next/timeout.js
@@ -1,26 +1,31 @@
 // @flow
 
 import uniqueId from 'lodash/uniqueId'
-import type {Action, TimeoutId, TimeoutOnEndActionCreator} from '../type-next'
+import type {Action, TimeoutId, TimeoutCallId, TimeoutOnEndActionCreator} from '../type-next'
 
 type StartAction = Action<
   'TIMEOUT.START',
-  {timeoutId: TimeoutId, onEndActionCreator: TimeoutOnEndActionCreator, delay: number}
+  {
+    timeoutId: TimeoutId,
+    timeoutCallId: TimeoutCallId,
+    onEndActionCreator: TimeoutOnEndActionCreator,
+    delay: number
+  }
 >
 type CancelAction = Action<'TIMEOUT.CANCEL', {timeoutId: TimeoutId}>
-type DebounceAction = Action<'TIMEOUT.DEBOUNCE', {timeoutId: TimeoutId, delay: number}>
-type InitiatorAction = StartAction | DebounceAction
-type EndAction = Action<'TIMEOUT.END', {initiatorAction: InitiatorAction}>
+type HandleEndAction = Action<'TIMEOUT.HANDLE_END', {timeoutCallId: TimeoutCallId}>
 
-export type TimeoutAction = StartAction | EndAction | DebounceAction | CancelAction
+export type TimeoutAction = StartAction | CancelAction | HandleEndAction
 
 export const start = (
   onEndActionCreator: TimeoutOnEndActionCreator,
-  delay: number
+  delay: number,
+  timeoutId: string = uniqueId('timeout-id-')
 ): StartAction => ({
   type: 'TIMEOUT.START',
   payload: {
-    timeoutId: uniqueId('timeout-id-'),
+    timeoutCallId: uniqueId('timeout-call-id-'),
+    timeoutId,
     onEndActionCreator,
     delay
   }
@@ -33,17 +38,9 @@ export const cancel = (timeoutId: TimeoutId): CancelAction => ({
   }
 })
 
-export const debounce = (timeoutId: TimeoutId, delay: number): DebounceAction => ({
-  type: 'TIMEOUT.DEBOUNCE',
+export const handleEnd = (timeoutCallId: TimeoutCallId): HandleEndAction => ({
+  type: 'TIMEOUT.HANDLE_END',
   payload: {
-    timeoutId,
-    delay
-  }
-})
-
-export const end = (initiatorAction: InitiatorAction): EndAction => ({
-  type: 'TIMEOUT.END',
-  payload: {
-    initiatorAction
+    timeoutCallId
   }
 })

--- a/src/app/reducer-next/core.js
+++ b/src/app/reducer-next/core.js
@@ -2,8 +2,7 @@
 
 import {loop, Cmd} from 'redux-loop'
 import {listMaterials} from '../service/printing-engine'
-import type {MaterialGroup} from '../type-next'
-import type {AppAction} from '../action-next'
+import type {AppAction, MaterialGroup} from '../type-next'
 import * as coreAction from '../action-next/core'
 
 export type CoreState = {

--- a/src/app/reducer-next/model.js
+++ b/src/app/reducer-next/model.js
@@ -4,8 +4,7 @@ import omit from 'lodash/omit'
 import {loop, Cmd} from 'redux-loop'
 import invariant from 'invariant'
 import {uploadModel} from '../service/printing-engine'
-import type {UploadingFile, FileId, Model, ModelId, BasketItem} from '../type-next'
-import type {AppAction} from '../action-next'
+import type {AppAction, UploadingFile, FileId, Model, ModelId, BasketItem} from '../type-next'
 import * as modelAction from '../action-next/model'
 
 export type ModelState = {

--- a/src/app/reducer-next/timeout.js
+++ b/src/app/reducer-next/timeout.js
@@ -1,0 +1,122 @@
+// @flow
+
+import omit from 'lodash/omit'
+import {loop, Cmd} from 'redux-loop'
+import timeout from 'timeout-as-promise'
+import invariant from 'invariant'
+import type {AppAction, TimeoutId, TimeoutOnEndActionCreator} from '../type-next'
+import * as timeoutAction from '../action-next/timeout'
+
+type InitiatorAction = {}
+
+export type TimeoutState = {
+  activeTimeouts: {
+    [id: TimeoutId]: {
+      initiatorAction: InitiatorAction,
+      onEndActionCreator: TimeoutOnEndActionCreator
+    }
+  }
+}
+
+const initialState: TimeoutState = {
+  activeTimeouts: {}
+}
+
+const assertActiveTimeout = (handler, state, action) => {
+  const {timeoutId} = action.payload
+  const activeTimeout = state.activeTimeouts[timeoutId]
+
+  invariant(activeTimeout, `Error in ${handler}(): There is no active timeout with id ${timeoutId}`)
+
+  return activeTimeout
+}
+
+const start = (state, action) => {
+  const {timeoutId, delay, onEndActionCreator} = action.payload
+
+  invariant(
+    timeoutId in state.activeTimeouts === false,
+    `Error in start(): There is already an active timeout with id ${timeoutId}`
+  )
+
+  return loop(
+    {
+      ...state,
+      activeTimeouts: {
+        ...state.activeTimeouts,
+        [timeoutId]: {
+          initiatorAction: action,
+          onEndActionCreator
+        }
+      }
+    },
+    Cmd.run(timeout, {
+      args: [delay],
+      successActionCreator: () => timeoutAction.end(action)
+    })
+  )
+}
+
+const debounce = (state, action) => {
+  const {timeoutId, delay} = action.payload
+  const activeTimeout = assertActiveTimeout('debounce', state, action)
+
+  return loop(
+    {
+      ...state,
+      activeTimeouts: {
+        ...state.activeTimeouts,
+        [timeoutId]: {
+          ...activeTimeout,
+          initiatorAction: action
+        }
+      }
+    },
+    Cmd.run(timeout, {
+      args: [delay],
+      successActionCreator: () => timeoutAction.end(action)
+    })
+  )
+}
+
+const cancel = (state, action) => {
+  const {timeoutId} = action.payload
+
+  return {
+    ...state,
+    activeTimeouts: omit(state.activeTimeouts, timeoutId)
+  }
+}
+
+const end = (state, action) => {
+  const {initiatorAction} = action.payload
+  const {timeoutId} = initiatorAction.payload
+  const activeTimeout = state.activeTimeouts[timeoutId]
+
+  return activeTimeout && activeTimeout.initiatorAction === initiatorAction
+    ? loop(
+        {
+          ...state,
+          activeTimeouts: omit(state.activeTimeouts, timeoutId)
+        },
+        Cmd.action(activeTimeout.onEndActionCreator())
+      )
+    : state
+}
+
+export const reducer = (state: TimeoutState = initialState, action: AppAction): TimeoutState => {
+  switch (action.type) {
+    case 'TIMEOUT.START':
+      return start(state, action)
+    case 'TIMEOUT.CANCEL':
+      return cancel(state, action)
+    case 'TIMEOUT.DEBOUNCE':
+      return debounce(state, action)
+    case 'TIMEOUT.END':
+      return end(state, action)
+    default:
+      return state
+  }
+}
+
+export default reducer

--- a/src/app/reducer-next/user.js
+++ b/src/app/reducer-next/user.js
@@ -7,7 +7,6 @@ import * as printingEngine from '../service/printing-engine'
 import * as userAction from '../action-next/user'
 import * as modalAction from '../action-next/modal'
 import * as coreAction from '../action-next/core'
-
 import * as userLib from '../lib/user'
 
 export type UserState = {

--- a/src/app/reducer/index.js
+++ b/src/app/reducer/index.js
@@ -13,6 +13,8 @@ import modal from '../reducer-next/modal'
 import type {ModalState} from '../reducer-next/modal'
 import model from '../reducer-next/model'
 import type {ModelState} from '../reducer-next/model'
+import timeout from '../reducer-next/timeout'
+import type {TimeoutState} from '../reducer-next/timeout'
 import legacyUser from './user'
 import legacyModal from './modal'
 import legacyModel from './model'
@@ -26,6 +28,7 @@ export type AppState = {
   model: ModelState,
   modal: ModalState,
   user: UserState,
+  timeout: TimeoutState,
   legacy: LegacyState,
   routing: any, // Managed by react-router-redux
   form: any // Managed by redux-form
@@ -36,6 +39,7 @@ const rootReducer = combineReducers({
   user,
   modal,
   model,
+  timeout,
   legacy: combineReducers({
     user: legacyUser,
     modal: legacyModal,

--- a/src/app/selector/timeout.js
+++ b/src/app/selector/timeout.js
@@ -1,0 +1,6 @@
+// @flow
+
+import type {AppState, TimeoutId} from '../type-next'
+
+export const isTimeoutActive = (state: AppState, timeoutId: TimeoutId): boolean =>
+  timeoutId in state.timeout.activeTimeouts

--- a/src/app/type-next.js
+++ b/src/app/type-next.js
@@ -130,7 +130,7 @@ export type Action<Type, Payload> = {
 }
 
 export type TimeoutId = string
-export type TimeoutOnEndAction = Action<string, {}>
+export type TimeoutOnEndActionCreator = () => _AppAction
 
 export type AppAction = _AppAction
 export type AppState = _AppState

--- a/src/app/type-next.js
+++ b/src/app/type-next.js
@@ -130,6 +130,7 @@ export type Action<Type, Payload> = {
 }
 
 export type TimeoutId = string
+export type TimeoutCallId = string
 export type TimeoutOnEndActionCreator = () => _AppAction
 
 export type AppAction = _AppAction

--- a/src/app/type-next.js
+++ b/src/app/type-next.js
@@ -122,7 +122,6 @@ type _ModalConfig<C> = {
 }
 
 export type ModalConfig = _ModalConfig<null | ModalContent>
-
 export type OpenModalConfig = _ModalConfig<ModalContent>
 
 export type Action<Type, Payload> = {
@@ -130,6 +129,8 @@ export type Action<Type, Payload> = {
   payload: Payload
 }
 
-export type AppAction = _AppAction
+export type TimeoutId = string
+export type TimeoutOnEndAction = Action<string, {}>
 
+export type AppAction = _AppAction
 export type AppState = _AppState

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -10,6 +10,7 @@
     "getModel": true,
     "getCmd": true,
     "findCmd": true,
+    "findAction": true,
     "createLegacyStore": true
   },
   "env": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -77,13 +77,17 @@ export const findCmd = (state, func, args) => {
   return cmd
 }
 
-export const findAction = (state, action) =>
-  getCmd(state).cmds.find(c => {
-    try {
-      expect(c.actionToDispatch, 'to satisfy', action)
+export const findAction = (state, actionOrFilter) =>
+  getCmd(state)
+    .cmds.map(c => c.actionToDispatch)
+    .filter(action => Boolean(action))
+    .find(action => {
+      if (typeof actionOrFilter === 'function') return actionOrFilter(action)
+      try {
+        expect(action, 'to satisfy', actionOrFilter)
 
-      return true
-    } catch (err) {
-      return false
-    }
-  })
+        return true
+      } catch (err) {
+        return false
+      }
+    })

--- a/test/helper.js
+++ b/test/helper.js
@@ -76,3 +76,14 @@ export const findCmd = (state, func, args) => {
 
   return cmd
 }
+
+export const findAction = (state, action) =>
+  getCmd(state).cmds.find(c => {
+    try {
+      expect(c.actionToDispatch, 'to satisfy', action)
+
+      return true
+    } catch (err) {
+      return false
+    }
+  })

--- a/test/integration/app/action-next/timeout.spec.js
+++ b/test/integration/app/action-next/timeout.spec.js
@@ -1,0 +1,285 @@
+import timeout from 'timeout-as-promise'
+import * as timeoutAction from '../../../../src/app/action-next/timeout'
+import {isTimeoutActive} from '../../../../src/app/selector/timeout'
+
+import reducer from '../../../../src/app/reducer'
+
+describe('timeout', () => {
+  describe('action.start()', () => {
+    const onEndActionCreator = () => ({type: 'SOME.ACTION'})
+    let startAction
+
+    beforeEach(() => {
+      startAction = timeoutAction.start(onEndActionCreator, 42)
+    })
+
+    it('creates a unique timeout id', () => {
+      const otherStartAction = timeoutAction.start(onEndActionCreator)
+
+      expect(startAction.payload.timeoutId, 'not to equal', otherStartAction.payload.timeoutId)
+    })
+
+    describe('when there is no active timeout with the given timeoutId', () => {
+      let state
+
+      beforeEach(() => {
+        state = reducer(undefined, startAction)
+      })
+
+      it('triggers timeoutAction.end() when the timeout resolves', () => {
+        const timeoutCmd = findCmd(state, timeout, [42])
+        const action = timeoutCmd.simulate({
+          success: true,
+          // The timeout library resolves with no result
+          result: undefined
+        })
+
+        expect(action, 'to equal', timeoutAction.end(startAction))
+      })
+
+      describe('selector.isTimeoutActive()', () => {
+        it('returns true for the given timeoutId', () => {
+          expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be true')
+        })
+      })
+    })
+
+    // May happen if someone dispatches the same action twice
+    describe('when there is an active timeout with the given timeoutId', () => {
+      it('throws an error', () => {
+        expect(
+          () =>
+            [startAction, startAction].reduce(
+              (currentState, action) => reducer(getModel(currentState), action),
+              undefined
+            ),
+          'to throw',
+          `Error in start(): There is already an active timeout with id ${startAction.payload
+            .timeoutId}`
+        )
+      })
+    })
+  })
+
+  describe('action.cancel()', () => {
+    const onEndActionCreator = () => ({type: 'SOME.ACTION'})
+    let startAction
+
+    beforeEach(() => {
+      startAction = timeoutAction.start(onEndActionCreator, 42)
+    })
+
+    describe('when there is no active timeout with the given timeoutId', () => {
+      it('throws no error', () => {
+        expect(() => reducer(undefined, timeoutAction.cancel('does-not-exist')), 'not to throw')
+      })
+    })
+
+    describe('when there is an active timeout with the given timeoutId', () => {
+      let cancelAction
+      let state
+
+      beforeEach(() => {
+        startAction = timeoutAction.start(onEndActionCreator, 42)
+        cancelAction = timeoutAction.cancel(startAction.payload.timeoutId)
+
+        state = [startAction, cancelAction].reduce(
+          (currentState, action) => reducer(getModel(currentState), action),
+          undefined
+        )
+      })
+
+      it('throws no error when dispatched multiple times', () => {
+        expect(
+          () =>
+            [cancelAction, timeoutAction.cancel(startAction.payload.timeoutId)].reduce(
+              (currentState, action) => reducer(getModel(currentState), action),
+              getModel(state)
+            ),
+          'not to throw'
+        )
+      })
+
+      describe('selector.isTimeoutActive()', () => {
+        it('returns false for the given timeoutId', () => {
+          expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be false')
+        })
+      })
+    })
+  })
+
+  describe('action.debounce()', () => {
+    describe('when there is no active timeout with the given timeoutId', () => {
+      it('throws an error', () => {
+        expect(
+          () => reducer(undefined, timeoutAction.debounce('does-not-exist')),
+          'to throw',
+          'Error in debounce(): There is no active timeout with id does-not-exist'
+        )
+      })
+    })
+
+    describe('when there is an active timeout with the given timeoutId', () => {
+      const onEndActionCreator = () => ({type: 'SOME.ACTION'})
+      let startAction
+      let debounceAction
+      let state
+
+      beforeEach(() => {
+        startAction = timeoutAction.start(onEndActionCreator, 42)
+        debounceAction = timeoutAction.debounce(startAction.payload.timeoutId, 4242)
+
+        state = [startAction, debounceAction].reduce(
+          (currentState, action) => reducer(getModel(currentState), action),
+          undefined
+        )
+      })
+
+      it('triggers timeoutAction.end() when the new timeout resolves', () => {
+        const timeoutCmd = findCmd(state, timeout, [4242])
+        const action = timeoutCmd.simulate({
+          success: true,
+          // The timeout library resolves with no result
+          result: undefined
+        })
+
+        expect(action, 'to equal', timeoutAction.end(debounceAction))
+      })
+
+      describe('selector.isTimeoutActive()', () => {
+        it('returns true for the given timeoutId', () => {
+          expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be true')
+        })
+      })
+    })
+  })
+
+  describe('action.end()', () => {
+    describe('when there is no active timeout with the given timeoutId', () => {
+      it('throws no error', () => {
+        expect(() => reducer(undefined, timeoutAction.cancel('does-not-exist')), 'not to throw')
+      })
+    })
+
+    describe('when there is an active timeout with the given timeoutId', () => {
+      const onEndActionCreator = () => ({type: 'SOME.ACTION'})
+      let startAction
+
+      beforeEach(() => {
+        startAction = timeoutAction.start(onEndActionCreator, 42)
+      })
+
+      describe('when the timeout has neither been cancelled nor debounced', () => {
+        let state
+
+        beforeEach(() => {
+          const endAction = timeoutAction.end(startAction)
+
+          state = [startAction, endAction].reduce(
+            (currentState, action) => reducer(getModel(currentState), action),
+            undefined
+          )
+        })
+
+        it('triggers the given onEndAction returned by the onEndActionCreator', () => {
+          const onEndAction = onEndActionCreator()
+
+          expect(findAction(state, onEndAction), 'to be truthy')
+        })
+
+        describe('selector.isTimeoutActive()', () => {
+          it('returns false for the given timeoutId', () => {
+            expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be false')
+          })
+        })
+      })
+
+      describe('when the timeout has been cancelled', () => {
+        let state
+
+        beforeEach(() => {
+          const cancelAction = timeoutAction.cancel(startAction.payload.timeoutId)
+          const endAction = timeoutAction.end(startAction)
+
+          state = [startAction, cancelAction, endAction].reduce(
+            (currentState, action) => reducer(getModel(currentState), action),
+            undefined
+          )
+        })
+
+        it('does not trigger the given onEndAction returned by the onEndActionCreator', () => {
+          const onEndAction = onEndActionCreator()
+
+          expect(findAction(state, onEndAction), 'to be falsy')
+        })
+
+        describe('selector.isTimeoutActive()', () => {
+          it('returns false for the given timeoutId', () => {
+            expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be false')
+          })
+        })
+      })
+
+      describe('when the timeout has been debounced', () => {
+        let state
+
+        beforeEach(() => {
+          startAction = timeoutAction.start(onEndActionCreator, 42)
+          const debounceAction = timeoutAction.debounce(startAction.payload.timeoutId, 4242)
+          const endAction = timeoutAction.end(startAction)
+
+          state = [startAction, debounceAction, endAction].reduce(
+            (currentState, action) => reducer(getModel(currentState), action),
+            undefined
+          )
+        })
+
+        it('does not trigger the given onEndAction returned by the original onEndActionCreator', () => {
+          const onEndAction = onEndActionCreator()
+
+          expect(findAction(state, onEndAction), 'to be falsy')
+        })
+
+        describe('selector.isTimeoutActive()', () => {
+          it('returns true for the given timeoutId', () => {
+            expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be true')
+          })
+        })
+      })
+    })
+  })
+
+  describe('selector.isTimeoutActive()', () => {
+    let state
+
+    beforeEach(() => {
+      const someInitAction = {}
+
+      state = reducer(undefined, someInitAction)
+    })
+
+    it('returns false for an unknown timeoutId', () => {
+      const startAction = timeoutAction.start(Function.prototype, 42)
+
+      expect(isTimeoutActive(getModel(state), startAction.payload.timeoutId), 'to be false')
+    })
+  })
+
+  describe('timeout-as-promise sanity check', () => {
+    it('should resolve after 0ms or more when called with 0', async () => {
+      const before = Date.now()
+      await timeout(0)
+      const now = Date.now()
+
+      expect(now - before, 'to be greater than', -1)
+    })
+
+    it('should resolve after 42ms or more when called with 42', async () => {
+      const before = Date.now()
+      await timeout(42)
+      const now = Date.now()
+
+      expect(now - before, 'to be greater than', 41)
+    })
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,7 +7,7 @@ import sinon from 'sinon'
 import fetch from 'isomorphic-fetch'
 import configureStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import {findCmd, createLegacyStore} from './helper'
+import {findCmd, findAction, createLegacyStore} from './helper'
 
 // Necessary because sinon does not wrap functions that do not exist
 // redux-loop sets Cmd.dispatch only if used with a real store
@@ -27,3 +27,4 @@ global.fetch = fetch
 global.getModel = getModel
 global.getCmd = getCmd
 global.findCmd = findCmd
+global.findAction = findAction


### PR DESCRIPTION
Closes https://github.com/all3dp/printing-engine-client/issues/550

Der Timeout-State wird vom Polling-State benötigt, da zwischen verschiedenen Retries ein Timeout gestartet wird. Diese generische Timeout-Implementierung erlaubt es uns, generell Timeouts (und gedebouncte Timeouts) im Redux-Store abzubilden.

Die Test-Implementierung war relativ aufwändig, da bestimmte Actions nur unter bestimmten Bedingungen Sinn machen bzw. erlaubt sind. Was passiert z.B. wenn ein Timeout gecancelt wurde, das vorher nicht gestartet wurde? Oder: Was passiert, wenn ein Timeout beendet wird, das gar nicht mehr existiert?

Um die Cases besser zu verstehen, macht es glaub ich Sinn, vorher den Test-Output durchzulesen. Das verdeutlicht ein bisschen besser die Test-Cases, die abgedeckt werden mussten:

![bildschirmfoto 2018-02-13 um 15 32 32](https://user-images.githubusercontent.com/781746/36156495-7c9bd3b0-10d7-11e8-9cfe-ee4155eb9f2f.jpg)

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
