### PR TITLE
Add magnifyable item

### DIFF
--- a/src/app/component/magnifyable-item.js
+++ b/src/app/component/magnifyable-item.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import propTypes from '../lib/prop-types'
+import buildClassName from '../lib/build-class-name'
+import {ariaButtonProps} from '../lib/aria'
+
+import Icon from './icon'
+import zoomIn from '../../asset/icon/zoom-in.svg'
+
+const MagnifyableItem = ({
+  classNames,
+  modifiers,
+  children,
+  ariaLabel,
+  onClick = Function.prototype
+}) => (
+  <div
+    className={buildClassName('magnifyable-item', modifiers, classNames)}
+    {...ariaButtonProps({ariaLabel, onClick})}
+  >
+    {children}
+    <Icon classNames={['magnifyable-item__icon']} source={zoomIn} title="" />
+  </div>
+)
+
+MagnifyableItem.propTypes = {
+  ...propTypes.component,
+  children: PropTypes.node.isRequired,
+  ariaLabel: PropTypes.string.isRequired,
+  onClick: PropTypes.func
+}
+
+export default MagnifyableItem

--- a/src/app/lib/aria.js
+++ b/src/app/lib/aria.js
@@ -1,0 +1,22 @@
+// @flow
+
+import invariant from 'invariant'
+
+export const ariaButtonProps = ({ariaLabel, onClick}: {ariaLabel: string, onClick: Function}) => {
+  invariant(ariaLabel, `Missing ariaLabel argument`)
+  invariant(onClick, `Missing onClick handler`)
+
+  return {
+    role: 'button',
+    'aria-label': ariaLabel,
+    tabIndex: 0,
+    onClick,
+    onKeyPress(event: KeyboardEvent) {
+      const isLikeOnClick = event.key === ' ' || event.key === 'Enter'
+
+      if (isLikeOnClick) {
+        onClick(event)
+      }
+    }
+  }
+}

--- a/src/asset/icon/zoom-in.svg
+++ b/src/asset/icon/zoom-in.svg
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
-    <path d="M0 0h24v24H0V0z" fill="none"/>
-    <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <path d="M12.5,11 L11.71,11 L11.43,10.73 C12.41,9.59 13,8.11 13,6.5 C13,2.91 10.09,0 6.5,0 C2.91,0 0,2.91 0,6.5 C0,10.09 2.91,13 6.5,13 C8.11,13 9.59,12.41 10.73,11.43 L11,11.71 L11,12.5 L16,17.49 L17.49,16 L12.5,11 Z M6.5,11 C4.01,11 2,8.99 2,6.5 C2,4.01 4.01,2 6.5,2 C8.99,2 11,4.01 11,6.5 C11,8.99 8.99,11 6.5,11 Z" id="Shape"></path>
+    <polygon points="9 7 7 7 7 9 6 9 6 7 4 7 4 6 6 6 6 4 7 4 7 6 9 6"></polygon>
 </svg>

--- a/src/asset/icon/zoom-in.svg
+++ b/src/asset/icon/zoom-in.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>
+    <path d="M0 0h24v24H0V0z" fill="none"/>
+    <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/>
+</svg>

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -129,3 +129,5 @@ $transition-duration: .4s;
 $transition-duration-fast: .15s;
 
 $global-stacking: app, tooltip, overlay, select-menu;
+
+$interface-touchable-min-size: 45px;

--- a/src/sass/component/_magnifyable-item.scss
+++ b/src/sass/component/_magnifyable-item.scss
@@ -1,0 +1,21 @@
+.magnifyable-item {
+  @include interface-touchable();
+
+  position: relative;
+  outline: 0;
+
+  &__icon {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    font-size: $font-size-xxl;
+    transform-origin: right bottom;
+    transition: transform $transition-duration-fast ease-out;
+  }
+
+  &:hover, &:focus {
+    .magnifyable-item__icon {
+      transform: scale(1.3);
+    }
+  }
+}

--- a/src/sass/component/_magnifyable-item.scss
+++ b/src/sass/component/_magnifyable-item.scss
@@ -3,19 +3,20 @@
 
   position: relative;
   outline: 0;
+  color: $color-invert-text;
 
   &__icon {
     position: absolute;
-    right: 0;
-    bottom: 0;
-    font-size: $font-size-xxl;
+    right: $space-s;
+    bottom: $space-s;
+    font-size: $font-size-xl;
     transform-origin: right bottom;
     transition: transform $transition-duration-fast ease-out;
   }
 
   &:hover, &:focus {
     .magnifyable-item__icon {
-      transform: scale(1.3);
+      transform: scale(1.1);
     }
   }
 }

--- a/src/sass/mixin/_interface.scss
+++ b/src/sass/mixin/_interface.scss
@@ -1,0 +1,44 @@
+// No default response (text selection, visual feedback, dialogs) as far as controllable via CSS
+@mixin interface-prevent-default() {
+  // We're using vendor prefixes for non-standardized properties because autoprefixer won't prefix them
+  // Prevent tap highlight on touch
+  -webkit-tap-highlight-color: transparent;
+  tap-highlight-color: transparent;
+
+  // Prevent text-selection
+  user-select: none;
+
+  // Prevent popup on touch-hold
+  -webkit-touch-callout: none;
+  touch-callout: none;
+
+  // Do not disable the outline, because the outline is important for motion impaired users for keyboard navigation
+  //outline: none;
+}
+
+// Enables interface behavior that is suited for interface elements that should be pressed either by a cursor or by
+// touch. Disables default interface behavior that might be distracting for pressable elements (like user-select).
+@mixin interface-pressable() {
+  @include interface-prevent-default();
+  cursor: pointer;
+}
+
+// You may need to set box-sizing: border-box if you also have a padding.
+@mixin interface-touchable() {
+  @include interface-pressable();
+
+  // According to several human interface guidelines the recommended touch target size
+  // @see http://www.lukew.com/ff/entry.asp?1085
+  min-width: $interface-touchable-min-size;
+  min-height: $interface-touchable-min-size;
+}
+
+// The element does not respond to user interactions
+@mixin interface-disabled() {
+  @include interface-prevent-default();
+  pointer-events: none;
+
+  // Prevent element from being selected by tabs
+  tab-index: -1;
+  outline: none;
+}

--- a/stories/component/magnifyable-item.js
+++ b/stories/component/magnifyable-item.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import {storiesOf} from '@storybook/react'
+import {action} from '@storybook/addon-actions'
+
+import MagnifyableItem from '../../src/app/component/magnifyable-item'
+
+const Item = () => <div style={{height: '300px'}} />
+
+storiesOf('Magnifyable Item', module)
+  .add('black on grey', () => (
+    <div style={{width: '50%', backgroundColor: 'lightgrey', color: 'black'}}>
+      <MagnifyableItem ariaLabel="Magnify that item" onClick={action('click')}>
+        <Item />
+      </MagnifyableItem>
+    </div>
+  ))
+  .add('white on black', () => (
+    <div style={{width: '50%', backgroundColor: 'black', color: 'white'}}>
+      <MagnifyableItem ariaLabel="Magnify that item" onClick={action('click')}>
+        <Item />
+      </MagnifyableItem>
+    </div>
+  ))

--- a/stories/component/magnifyable-item.js
+++ b/stories/component/magnifyable-item.js
@@ -6,18 +6,10 @@ import MagnifyableItem from '../../src/app/component/magnifyable-item'
 
 const Item = () => <div style={{height: '300px'}} />
 
-storiesOf('Magnifyable Item', module)
-  .add('black on grey', () => (
-    <div style={{width: '50%', backgroundColor: 'lightgrey', color: 'black'}}>
-      <MagnifyableItem ariaLabel="Magnify that item" onClick={action('click')}>
-        <Item />
-      </MagnifyableItem>
-    </div>
-  ))
-  .add('white on black', () => (
-    <div style={{width: '50%', backgroundColor: 'black', color: 'white'}}>
-      <MagnifyableItem ariaLabel="Magnify that item" onClick={action('click')}>
-        <Item />
-      </MagnifyableItem>
-    </div>
-  ))
+storiesOf('Magnifyable Item', module).add('default', () => (
+  <div style={{width: '50%', backgroundColor: 'black'}}>
+    <MagnifyableItem ariaLabel="Magnify that item" onClick={action('click')}>
+      <Item />
+    </MagnifyableItem>
+  </div>
+))

--- a/test/unit/app/lib/aria.spec.js
+++ b/test/unit/app/lib/aria.spec.js
@@ -1,0 +1,53 @@
+import {ariaButtonProps} from '../../../../src/app/lib/aria'
+
+describe('ariaButtonProps()', () => {
+  it('returns all the necessary props to mimic a button', () => {
+    const ariaLabel = 'Some label'
+    const onClick = () => {}
+    const props = ariaButtonProps({ariaLabel, onClick})
+
+    expect(props, 'to satisfy', {
+      role: 'button',
+      'aria-label': ariaLabel,
+      tabIndex: 0,
+      onClick
+    })
+  })
+
+  it('returns a keypress handler', () => {
+    const ariaLabel = 'Some label'
+    const onClick = sinon.spy()
+    const props = ariaButtonProps({ariaLabel, onClick})
+
+    expect(props.onKeyPress, 'to be a', Function)
+  })
+
+  it('triggers the onClick handler when the space key is pressed', () => {
+    const ariaLabel = 'Some label'
+    const onClick = sinon.spy()
+    const props = ariaButtonProps({ariaLabel, onClick})
+    const keyboardEvent = {key: ' '}
+
+    props.onKeyPress(keyboardEvent)
+    expect(onClick, 'was called with', keyboardEvent)
+  })
+
+  it('triggers the onClick handler when the enter key is pressed', () => {
+    const ariaLabel = 'Some label'
+    const onClick = sinon.spy()
+    const props = ariaButtonProps({ariaLabel, onClick})
+    const keyboardEvent = {key: 'Enter'}
+
+    props.onKeyPress(keyboardEvent)
+    expect(onClick, 'was called with', keyboardEvent)
+  })
+
+  it('throws no error a non-enter key is pressed', () => {
+    const ariaLabel = 'Some label'
+    const onClick = sinon.spy()
+    const props = ariaButtonProps({ariaLabel, onClick})
+    const keyboardEvent = {key: 'a'}
+
+    expect(() => props.onKeyPress(keyboardEvent), 'not to throw')
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/all3dp/printing-engine-client/issues/444

In Vorbereitung für https://github.com/all3dp/printing-engine-client/issues/425. [Die Komponente kann aktuell nur im Storybook getestet werden](http://localhost:3001/?selectedKind=Magnifyable%20Item&selectedStory=white%20on%20black&full=0&down=1&left=1&panelRight=0&downPanel=storybook%2Factions%2Factions-panel), die Integration folgt in einem anderen PR.

# Definition of Done

- [x] The code does at least what is defined in the ticket and does not affect any other functionality
- [x] The PR has a meaningful title
- [x] There is a link to the issue-id
- [x] There are no 'hacks' or shortcuts refactoring is preferred
- [x] The happy case of the app was tested at least once manually
