### PR TITLE
Add http lib

### DIFF
--- a/src/app/lib/error.js
+++ b/src/app/lib/error.js
@@ -1,16 +1,48 @@
-import {ERROR_TYPE} from '../action-type'
+// @flow
 
+export type ErrorType =
+  | 'HTTP_RESPONSE_UNEXPECTED_STATUS_ERROR'
+  | 'HTTP_RESPONSE_BODY_PARSE_ERROR'
+  | 'LEGACY.FILE_UPLOAD_FAILED'
+
+// TODO: Make this private. There should be a dedicated error class for every error type
 export class AppError extends Error {
-  constructor(type, message) {
+  // TODO: This should just be ErrorType in the future
+  type: ErrorType | string
+  constructor(type: ErrorType | string, message: string) {
     super(`${message} (${type})`)
     this.type = type
   }
 }
 
-export class FileUploadError extends AppError {
-  constructor(fileId) {
+export class HttpResponseUnexpectedStatusError extends AppError {
+  response: Response
+  bodyText: string | null
+  constructor(expectedStatus: string, response: Response, bodyText: string | null = null) {
     super(
-      ERROR_TYPE.FILE_UPLOAD_FAILED,
+      'HTTP_RESPONSE_UNEXPECTED_STATUS_ERROR',
+      `${response.url} returned with unexpected status ${response.status} ${response.statusText}. Expected status to be ${expectedStatus}.`
+    )
+    this.response = response
+    this.bodyText = bodyText
+  }
+}
+
+export class HttpResponseBodyParseError extends AppError {
+  response: Response
+  bodyText: string | null
+  constructor(cause: string, response: Response, bodyText: string | null = null) {
+    super('HTTP_RESPONSE_BODY_PARSE_ERROR', `Cannot parse response from ${response.url}: ${cause}`)
+    this.response = response
+    this.bodyText = bodyText
+  }
+}
+
+export class FileUploadError extends AppError {
+  fileId: string
+  constructor(fileId: string) {
+    super(
+      'LEGACY.FILE_UPLOAD_FAILED',
       'File upload failed. Maybe the file is corrupted or not in a format compatible for 3D printing.'
     )
     this.fileId = fileId

--- a/src/app/lib/http.js
+++ b/src/app/lib/http.js
@@ -1,0 +1,56 @@
+// @flow
+
+import {HttpResponseUnexpectedStatusError, HttpResponseBodyParseError} from './error'
+import * as http from '../service/http-next'
+
+const getBodyTextIfPossible = async (response: Response): Promise<string | null> => {
+  try {
+    return await response.text()
+  } catch (_) {
+    return null
+  }
+}
+
+export const fetchJson = async (
+  url: RequestInfo,
+  options?: {
+    headers?: Headers,
+    method?: string,
+    body?: Object
+  } = {}
+): Promise<{
+  json: any,
+  response: Response
+}> => {
+  const headers = new http.Headers(options.headers)
+  const fetchOptions: RequestOptions = {
+    headers
+  }
+
+  headers.set('Content-Type', 'application/json')
+  if (options.body) {
+    fetchOptions.body = JSON.stringify(options.body)
+  }
+
+  const response = await http.fetch(url, fetchOptions)
+
+  if (response.ok === false) {
+    throw new HttpResponseUnexpectedStatusError(
+      '2xx',
+      response,
+      await getBodyTextIfPossible(response)
+    )
+  }
+  try {
+    return {
+      json: await response.json(),
+      response
+    }
+  } catch (err) {
+    throw new HttpResponseBodyParseError(
+      err.message,
+      response,
+      await getBodyTextIfPossible(response)
+    )
+  }
+}

--- a/src/app/service/http-next.js
+++ b/src/app/service/http-next.js
@@ -1,0 +1,4 @@
+// @flow
+/* global Headers, fetch */
+
+export {Headers, fetch}

--- a/test/unit/app/lib/error.spec.js
+++ b/test/unit/app/lib/error.spec.js
@@ -1,5 +1,9 @@
-import {AppError, FileUploadError} from '../../../../src/app/lib/error'
-import {ERROR_TYPE} from '../../../../src/app/action-type'
+import {
+  AppError,
+  HttpResponseUnexpectedStatusError,
+  HttpResponseBodyParseError,
+  FileUploadError
+} from '../../../../src/app/lib/error'
 
 describe('Error lib', () => {
   describe('AppError', () => {
@@ -14,12 +18,67 @@ describe('Error lib', () => {
     })
   })
 
+  describe('HttpResponseUnexpectedStatusError', () => {
+    it('sets type, message, response and bodyText', () => {
+      const response = {
+        status: 400,
+        statusText: 'Bad Request',
+        url: 'http://example.com'
+      }
+      const error = new HttpResponseUnexpectedStatusError('2xx', response, 'Server error')
+      expect(error, 'to satisfy', {
+        type: 'HTTP_RESPONSE_UNEXPECTED_STATUS_ERROR',
+        message: expect.it(
+          'to contain',
+          'http://example.com returned with unexpected status 400 Bad Request. Expected status to be 2xx.'
+        ),
+        response,
+        bodyText: 'Server error'
+      })
+    })
+    it('sets bodyText null as default', () => {
+      const error = new HttpResponseUnexpectedStatusError('2xx', {
+        status: 400,
+        statusText: 'Bad Request',
+        url: 'http://example.com'
+      })
+      expect(error.bodyText, 'to be', null)
+    })
+  })
+
+  describe('HttpResponseBodyParseError', () => {
+    it('sets type, message, response and bodyText', () => {
+      const response = {
+        url: 'http://example.com'
+      }
+      const error = new HttpResponseBodyParseError('Unexpected token', response, '{')
+      expect(error, 'to satisfy', {
+        type: 'HTTP_RESPONSE_BODY_PARSE_ERROR',
+        message: expect.it(
+          'to contain',
+          'Cannot parse response from http://example.com: Unexpected token'
+        ),
+        response,
+        bodyText: '{'
+      })
+    })
+    it('sets bodyText null as default', () => {
+      const error = new HttpResponseBodyParseError('Unexpected token', {
+        url: 'http://example.com'
+      })
+      expect(error.bodyText, 'to be', null)
+    })
+  })
+
   describe('FileUploadError', () => {
-    it('sets fileId, type and message', () => {
+    it('sets type, message and fileId', () => {
       const error = new FileUploadError('some-file-id')
       expect(error, 'to satisfy', {
-        type: ERROR_TYPE.FILE_UPLOAD_FAILED,
-        message: expect.it('to be a string'),
+        type: 'LEGACY.FILE_UPLOAD_FAILED',
+        message: expect.it(
+          'to contain',
+          'File upload failed. Maybe the file is corrupted or not in a format compatible for 3D printing.'
+        ),
         fileId: 'some-file-id'
       })
     })

--- a/test/unit/app/lib/http.spec.js
+++ b/test/unit/app/lib/http.spec.js
@@ -1,0 +1,164 @@
+import * as http from '../../../../src/app/service/http-next'
+import {fetchJson} from '../../../../src/app/lib/http'
+import {
+  HttpResponseUnexpectedStatusError,
+  HttpResponseBodyParseError
+} from '../../../../src/app/lib/error'
+
+const expectAnything = expect.it(() => {})
+
+describe('http lib', () => {
+  let headersMock
+  let responseMock
+  let sandbox
+
+  beforeEach(() => {
+    headersMock = {
+      set: () => {}
+    }
+    responseMock = {
+      ok: true,
+      json: () => {},
+      text: () => {}
+    }
+    sandbox = sinon.sandbox.create()
+    sandbox.stub(http, 'fetch').resolves(responseMock)
+    sandbox.stub(http, 'Headers').returns(headersMock)
+  })
+  afterEach(() => {
+    sandbox.restore()
+  })
+  describe('fetchJson()', () => {
+    it('calls http.fetch() with the given url', async () => {
+      await fetchJson('http://example.com')
+      expect(http.fetch, 'to have a call satisfying', ['http://example.com', expectAnything])
+    })
+
+    it('calls http.fetch() with default headers', async () => {
+      headersMock.set = sinon.spy()
+      await fetchJson('http://example.com')
+      expect(http.fetch, 'to have a call satisfying', [
+        expectAnything,
+        {
+          headers: expect.it(headers => {
+            expect(headers.set, 'to have a call satisfying', ['Content-Type', 'application/json'])
+          })
+        }
+      ])
+    })
+
+    it('allows to set custom headers', async () => {
+      const customHeaders = {
+        Some: 'Header'
+      }
+
+      await fetchJson('http://example.com', {
+        headers: customHeaders
+      })
+      expect(http.Headers, 'to have a call satisfying', [customHeaders])
+    })
+
+    it('stringifies the body if present', async () => {
+      const body = {some: 'value'}
+
+      await fetchJson('http://example.com', {
+        body
+      })
+      expect(http.fetch, 'to have a call satisfying', [
+        expectAnything,
+        {
+          headers: expectAnything,
+          body: JSON.stringify(body)
+        }
+      ])
+    })
+
+    it('parses the JSON response', async () => {
+      responseMock.json = sinon.spy()
+      await fetchJson('http://example.com')
+      expect(responseMock.json, 'to have a call satisfying', [])
+    })
+
+    it('returns the json and the raw response', async () => {
+      const json = {some: 'value'}
+
+      sinon.stub(responseMock, 'json').resolves(json)
+      expect(await fetchJson('http://example.com'), 'to satisfy', {
+        json,
+        response: responseMock
+      })
+    })
+
+    it('throws a HttpResponseUnexpectedStatusError if the response was not ok', async () => {
+      let error
+
+      responseMock.ok = false
+
+      sinon.stub(responseMock, 'text').resolves('Raw text response')
+      try {
+        await fetchJson('http://example.com')
+      } catch (err) {
+        error = err
+      }
+
+      expect(
+        error,
+        'to equal',
+        new HttpResponseUnexpectedStatusError('2xx', responseMock, 'Raw text response')
+      )
+    })
+
+    it('initializes HttpResponseUnexpectedStatusError with a bodyText being null when the raw text response was not available', async () => {
+      let error
+
+      responseMock.ok = false
+
+      sinon.stub(responseMock, 'text').rejects(new Error('Something went really really wrong'))
+      try {
+        await fetchJson('http://example.com')
+      } catch (err) {
+        error = err
+      }
+
+      expect(error, 'to equal', new HttpResponseUnexpectedStatusError('2xx', responseMock, null))
+    })
+
+    it('throws a HttpResponseBodyParseError if response.json() rejected with an error', async () => {
+      const someError = new Error('Some error')
+      let error
+
+      sinon.stub(responseMock, 'json').rejects(someError)
+      sinon.stub(responseMock, 'text').resolves('Raw text response')
+      try {
+        await fetchJson('http://example.com')
+      } catch (err) {
+        error = err
+      }
+
+      expect(
+        error,
+        'to equal',
+        new HttpResponseBodyParseError(someError.message, responseMock, 'Raw text response')
+      )
+    })
+
+    it('initializes HttpResponseUnexpectedStatusError with a bodyText being null when the raw text response was not available', async () => {
+      const someError = new Error('Some error')
+      let error
+
+      sinon.stub(responseMock, 'json').rejects(someError)
+      sinon.stub(responseMock, 'text').rejects(new Error('Something went really really wrong'))
+      try {
+        await fetchJson('http://example.com')
+      } catch (err) {
+        error = err
+      }
+
+      expect(
+        error,
+        'to equal',
+        new HttpResponseBodyParseError(someError.message, responseMock, null)
+      )
+    })
+  })
+})


### PR DESCRIPTION
Da ich für den Model-Viewer einen neuen HTTP-Call schreiben muss und getreu dem Motto "There are no 'hacks' or shortcuts refactoring is preferred", bin ich dem Aufruf in `service/http.js` gefolgt und habe eine HTTP lib angelegt 😁. Diese verwendet `service/http-next`, welcher nur die jeweiligen Browser-Primitiven aus der `fetch`-API exportiert.

Da die HTTP-Lib auch mit Fehlern arbeiten muss, hab ich angefangen, in der `lib/error.js` HTTP-spezifische Errors anzulegen. Wir sollten auch in Zukunft die `ERROR_TYPE` aus dem `action-type`-Modul deprecaten bzw. beim Refactoring umziehen, da die error types eigentlich nicht da reingehören.

In Zukunft fände ich es gut, wenn wir für jeden Fehler, der in unserer App vorkommen kann, einen Fehlertyp definieren. Diese speziellen Fehlertypen sollten noch fehlerspezifische Zusatzinformationen halten.

In Vorbereitung für #425 

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
