### PR TITLE
Refactor modal next implementation

### DIFF
--- a/src/app/action-next/modal.js
+++ b/src/app/action-next/modal.js
@@ -1,33 +1,42 @@
 // @flow
 
-import type {Action, OpenModalConfig} from '../type-next'
+import type {Action, ModalConfigOpened, ModelId} from '../type-next'
 
-type OpenModalAction = Action<'MODAL.OPEN_MODAL', OpenModalConfig>
-type CloseModalAction = Action<'MODAL.CLOSE_MODAL', void>
+type OpenModalAction = Action<'MODAL.OPEN', ModalConfigOpened>
+type CloseModalAction = Action<'MODAL.CLOSE', void>
 export type ModalAction = OpenModalAction | CloseModalAction
 
-export const openModal = (config: OpenModalConfig): OpenModalAction => ({
-  type: 'MODAL.OPEN_MODAL',
+const open = (config: ModalConfigOpened): OpenModalAction => ({
+  type: 'MODAL.OPEN',
   payload: config
 })
 
-export const openFatalErrorModal = (error: Error): OpenModalAction =>
-  openModal({
+export const openPickLocation = (): OpenModalAction =>
+  open({
     isCloseable: false,
-    content: 'FATAL_ERROR',
+    contentId: 'PICK_LOCATION',
+    contentProps: null
+  })
+
+export const openModelViewer = (modelId: ModelId): OpenModalAction =>
+  open({
+    isCloseable: true,
+    contentId: 'MODEL_VIEWER',
+    contentProps: {
+      modelId
+    }
+  })
+
+export const openFatalError = (error: Error): OpenModalAction =>
+  open({
+    isCloseable: false,
+    contentId: 'FATAL_ERROR',
     contentProps: {
       error
     }
   })
 
-export const openPickLocationModal = (): OpenModalAction =>
-  openModal({
-    isCloseable: false,
-    content: 'PICK_LOCATION',
-    contentProps: null
-  })
-
-export const closeModal = (): CloseModalAction => ({
-  type: 'MODAL.CLOSE_MODAL',
+export const close = (): CloseModalAction => ({
+  type: 'MODAL.CLOSE',
   payload: undefined
 })

--- a/src/app/reducer-next/modal.js
+++ b/src/app/reducer-next/modal.js
@@ -2,31 +2,28 @@
 
 import type {AppAction, ModalConfig} from '../type-next'
 
-export type ModalState = ModalConfig & {
-  isOpen: boolean
+export type ModalState = {
+  isOpen: boolean,
+  modalConfig: ModalConfig
 }
 
 const initialState: ModalState = {
   isOpen: false,
-  isCloseable: true,
-  content: null,
-  contentProps: null
+  modalConfig: null
 }
 
 const openModal = (state, action) => ({
   isOpen: true,
-  isCloseable: action.payload.isCloseable,
-  content: action.payload.content,
-  contentProps: action.payload.contentProps
+  modalConfig: action.payload
 })
 
 const closeModal = (_state, _action) => initialState
 
 const reducer = (state: ModalState = initialState, action: AppAction): ModalState => {
   switch (action.type) {
-    case 'MODAL.OPEN_MODAL':
+    case 'MODAL.OPEN':
       return openModal(state, action)
-    case 'MODAL.CLOSE_MODAL':
+    case 'MODAL.CLOSE':
       return closeModal(state, action)
     default:
       return state

--- a/src/app/reducer-next/user.js
+++ b/src/app/reducer-next/user.js
@@ -26,7 +26,7 @@ const detectLocation = (state, _action) =>
     state,
     Cmd.run(getLocationByIp, {
       successActionCreator: userAction.locationDetected,
-      failActionCreator: modalAction.openPickLocationModal,
+      failActionCreator: modalAction.openPickLocation,
       args: []
     })
   )

--- a/src/app/selector/modal.js
+++ b/src/app/selector/modal.js
@@ -3,8 +3,4 @@
 import type {AppState, ModalConfig} from '../type-next'
 
 export const isModalOpen = (state: AppState): boolean => state.modal.isOpen
-export const selectModalConfig = (state: AppState): ModalConfig => ({
-  isCloseable: state.modal.isCloseable,
-  content: state.modal.content,
-  contentProps: state.modal.contentProps
-})
+export const selectModalConfig = (state: AppState): ModalConfig => state.modal.modalConfig

--- a/src/app/type-next.js
+++ b/src/app/type-next.js
@@ -75,7 +75,7 @@ export type UploadingFile = {
 }
 
 export type ModelId = string
-
+export type ModelSceneId = string
 export type Model = {
   modelId: ModelId,
   fileName: string,
@@ -87,7 +87,8 @@ export type Model = {
     y: ?number,
     z: ?number
   },
-  thumbnailUrl: string
+  thumbnailUrl: string,
+  sceneId?: ModelSceneId
 }
 
 export type BasketItem = {
@@ -118,16 +119,14 @@ export type GoogleMapsPlace = {
   }>
 }
 
-export type ModalContent = 'PICK_LOCATION' | 'FATAL_ERROR'
-
-type _ModalConfig<C> = {
+export type ModalContent = 'PICK_LOCATION' | 'MODEL_VIEWER' | 'FATAL_ERROR'
+export type ModalConfigClosed = null
+export type ModalConfigOpened = {
   isCloseable: boolean,
-  content: C,
+  contentId: string,
   contentProps: any
 }
-
-export type ModalConfig = _ModalConfig<null | ModalContent>
-export type OpenModalConfig = _ModalConfig<ModalContent>
+export type ModalConfig = ModalConfigOpened | null
 
 export type TimeoutId = string
 export type TimeoutCallId = string
@@ -135,7 +134,7 @@ export type TimeoutOnEndActionCreator = () => _AppAction
 
 export type PollingId = string
 export type PollingResult = any
-export type PollingFunction = () => Promise<PollingResult>
+export type PollingFunction = (...args: any) => Promise<PollingResult>
 export type PollingArgs = Array<any>
 export type PollingOnSuccessActionCreator = (result: PollingResult) => _AppAction
 

--- a/test/integration/app/action-next/init.spec.js
+++ b/test/integration/app/action-next/init.spec.js
@@ -36,7 +36,7 @@ describe('init action', () => {
       [selector.selectCurrency, 'USD'],
       [selector.selectLocation, null],
       [selector.isModalOpen, false],
-      [selector.selectModalConfig, {isCloseable: true, content: null, contentProps: null}]
+      [selector.selectModalConfig, null]
     ].forEach(([testSelector, expected]) => {
       it(`${testSelector.name}() returns the expected result after execution`, () => {
         expect(testSelector(getModel(state)), 'to equal', expected)
@@ -76,14 +76,14 @@ describe('init action', () => {
       expect(action, 'to equal', userAction.locationDetected(geolocationSuccessResponse))
     })
 
-    it(`triggers the modalAction.openPickLocationModal() action when getLocationByIp failed`, () => {
+    it(`triggers the modalAction.openPickLocation() action when getLocationByIp failed`, () => {
       const err = new Error('Some error')
       const cmd = findCmd(state, getLocationByIp, [])
       const action = cmd.simulate({
         success: false,
         result: err
       })
-      expect(action, 'to equal', modalAction.openPickLocationModal())
+      expect(action, 'to equal', modalAction.openPickLocation())
     })
   })
 })

--- a/test/integration/app/action-next/modal.spec.js
+++ b/test/integration/app/action-next/modal.spec.js
@@ -2,85 +2,65 @@ import * as modalAction from '../../../../src/app/action-next/modal'
 import {isModalOpen, selectModalConfig} from '../../../../src/app/selector'
 import reducer from '../../../../src/app/reducer'
 
-describe('modal action', () => {
-  describe('openModal()', () => {
-    let modalConfiguration
-    let state
-
-    beforeEach(() => {
-      modalConfiguration = {
-        isCloseable: false,
-        content: 'CONTENT_TYPE',
-        contentProps: {}
+describe('modal', () => {
+  const someError = new Error('some-error')
+  ;[
+    {
+      description: 'action.openPickLocation()',
+      action: modalAction.openPickLocation(),
+      expectedModalConfig: {isCloseable: false, contentId: 'PICK_LOCATION', contentProps: null}
+    },
+    {
+      description: 'action.openModelViewer()',
+      action: modalAction.openModelViewer('some-model-id'),
+      expectedModalConfig: {
+        isCloseable: true,
+        contentId: 'MODEL_VIEWER',
+        contentProps: {modelId: 'some-model-id'}
       }
-      state = reducer(undefined, modalAction.openModal(modalConfiguration))
-    })
+    },
+    {
+      description: 'action.openFatalError()',
+      action: modalAction.openFatalError(someError),
+      expectedModalConfig: {
+        isCloseable: false,
+        contentId: 'FATAL_ERROR',
+        contentProps: {error: someError}
+      }
+    }
+  ].forEach(({description, action, expectedModalConfig}) => {
+    describe(description, () => {
+      const stringifiedModalConfig = JSON.stringify(expectedModalConfig).slice(1, -1)
+      let state
 
-    describe('using isModalOpen() selector', () => {
-      it('returns true', () => expect(isModalOpen(getModel(state)), 'to be', true))
-    })
+      beforeEach(() => {
+        state = reducer(undefined, action)
+      })
 
-    describe('using selectModalConfig() selector', () => {
-      it('returns the specified modal configuration', () =>
-        expect(selectModalConfig(getModel(state)), 'to satisfy', modalConfiguration))
-    })
-  })
+      describe('selector.isModalOpen()', () => {
+        it('returns true', () => expect(isModalOpen(getModel(state)), 'to be', true))
+      })
 
-  describe('openFatalErrorModal()', () => {
-    let error
-    let state
-
-    beforeEach(() => {
-      error = new Error('Fatal error')
-      state = reducer(undefined, modalAction.openFatalErrorModal(error))
-    })
-
-    describe('using isModalOpen() selector', () => {
-      it('returns true', () => expect(isModalOpen(getModel(state)), 'to be', true))
-    })
-
-    describe('using selectModalConfig() selector', () => {
-      it('returns the expected modal configuration', () =>
-        expect(selectModalConfig(getModel(state)), 'to satisfy', {
-          isCloseable: false,
-          content: 'FATAL_ERROR',
-          contentProps: {
-            error
-          }
-        }))
+      describe('selector.selectModalConfig()', () => {
+        it(`satisfies ${stringifiedModalConfig}`, () =>
+          expect(selectModalConfig(getModel(state)), 'to satisfy', expectedModalConfig))
+      })
     })
   })
 
-  describe('openPickLocationModal()', () => {
+  describe('action.closeModal()', () => {
     let state
 
     beforeEach(() => {
-      state = reducer(undefined, modalAction.openPickLocationModal())
+      state = reducer(undefined, modalAction.close())
     })
 
-    describe('using isModalOpen() selector', () => {
-      it('returns true', () => expect(isModalOpen(getModel(state)), 'to be', true))
-    })
-
-    describe('using selectModalConfig() selector', () => {
-      it('returns the expected modal configuration', () =>
-        expect(selectModalConfig(getModel(state)), 'to satisfy', {
-          isCloseable: false,
-          content: 'PICK_LOCATION',
-          contentProps: null
-        }))
-    })
-  })
-
-  describe('closeModal()', () => {
-    let state
-
-    beforeEach(() => {
-      state = reducer(undefined, modalAction.closeModal())
-    })
-
-    describe('using isModalOpen() selector', () => {
+    describe('selector.isModalOpen()', () => {
       it('returns false', () => expect(isModalOpen(getModel(state)), 'to be', false))
+    })
+
+    describe('selector.selectModalConfig()', () => {
+      it('equals null', () => expect(selectModalConfig(getModel(state)), 'to be', null))
     })
   })
 })


### PR DESCRIPTION
Im Zuge von #425 hab ich die Modal-Implementierung ein bisschen angepasst. Die war ja während den redux-loop-Experimenten entstanden, wird aber aktuell noch nicht verwendet.

Da ich dabei die `type-next.js` anfassen musste, sind da schon Typen für den ModelViewer dabei (ebenso auch schon das ModelViewer-Modal :))

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
