### PR TITLE
Remove sudo:false from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - "10"


### PR DESCRIPTION
Removed `sudo:false` config according to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

# Definition of Done

- [ ] The code does at least what is defined in the ticket and does not affect any other functionality
- [ ] The PR has a meaningful title
- [ ] There is a link to the issue-id
- [ ] There are no 'hacks' or shortcuts refactoring is preferred
- [ ] The happy case of the app was tested at least once manually
