### PR TITLE
Use new /offer/:id/cart route for fetching a cart for an offer id

### DIFF
--- a/src/app/lib/printing-engine.spec.js
+++ b/src/app/lib/printing-engine.spec.js
@@ -297,7 +297,7 @@ describe('printing-engine lib', () => {
 
     it('calls httpJson.fetch() with the correct URL', () =>
       expect(httpJson.fetch, 'to have a call satisfying', [
-        `SOME-BASE-URL/v3/offer/some-offer-id?currency=some-currency`
+        `SOME-BASE-URL/v3/offer/some-offer-id/cart?currency=some-currency`
       ]))
 
     it('returns the json result', () => expect(result, 'to equal', 'some-offer-result'))

--- a/src/app/lib/printing-engine.ts
+++ b/src/app/lib/printing-engine.ts
@@ -261,7 +261,7 @@ export const getOffer = async (
   currency: string
 ): Promise<CartOfferResponse> => {
   const response = await httpJson.fetch(
-    `${config.printingEngineBaseUrl}/v3/offer/${offerId}?currency=${currency}`
+    `${config.printingEngineBaseUrl}/v3/offer/${offerId}/cart?currency=${currency}`
   )
   return response.json
 }


### PR DESCRIPTION
Frontend change for API change of https://github.com/all3dp/printing-engine/issues/1614 in https://github.com/all3dp/printing-engine/pull/1652